### PR TITLE
Add site visitor counter badge

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -946,3 +946,43 @@ button {
     padding: 14px;
   }
 }
+
+.visitor-counter {
+  position: fixed;
+  left: 20px;
+  bottom: 20px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+}
+
+.visitor-counter-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 3px rgba(141, 216, 182, 0.18);
+}
+
+.visitor-counter [data-visitor-count] {
+  color: var(--text);
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .visitor-counter {
+    left: 12px;
+    bottom: 12px;
+    padding: 6px 12px;
+    font-size: 0.75rem;
+  }
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -139,9 +139,32 @@ window.addEventListener('hashchange', () => {
   showPage(pageName);
 });
 
+function renderVisitorCounter() {
+  const badge = document.createElement('div');
+  badge.className = 'visitor-counter';
+  badge.setAttribute('role', 'status');
+  badge.setAttribute('aria-label', 'Site visitor count');
+  badge.innerHTML =
+    '<span class="visitor-counter-dot"></span><span data-visitor-count>—</span><span class="visitor-counter-label">visitors</span>';
+  document.body.append(badge);
+
+  fetch('https://countapi.mileshilliard.com/api/v1/hit/ramguthula-com-site-visits')
+    .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+    .then((data) => {
+      if (typeof data.value !== 'number') {
+        throw new Error('Unexpected visitor counter response');
+      }
+      badge.querySelector('[data-visitor-count]').textContent = data.value.toLocaleString();
+    })
+    .catch(() => {
+      badge.remove();
+    });
+}
+
 renderHomepageArticles();
 renderRelatedArticles();
 enableAnalytics();
+renderVisitorCounter();
 showPage(window.location.hash.replace('#', '') || 'about');
 
 /* ==========================================================================


### PR DESCRIPTION
Renders a small fixed-position badge showing a live site visit count, backed by the free countapi.mileshilliard.com hit-counter API (no signup or backend required). Added once in script.js so it appears on every page automatically. Fails silently (badge removes itself) if the counter API is unreachable.